### PR TITLE
[Feat/#4] chore: 프로젝트 진입점 생성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,11 @@
 
 # lgtm
 monitoring/container/
+
+# env
+.env.*
+
+# let's encrypt
+gateway/nginx/letsencrypt
+gateway/nginx/www
+gateway/nginx/logs

--- a/gateway/docker-compose.yaml
+++ b/gateway/docker-compose.yaml
@@ -1,0 +1,24 @@
+services:
+  nginx:
+    image: nginx:stable
+    container_name: gateway-nginx
+    restart: always
+    ports:
+      - "80:80" # HTTP
+      - "443:443" # HTTPS
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
+      - ./nginx/letsencrypt:/etc/letsencrypt
+      - ./nginx/www:/var/www/certbot
+      - ./nginx/logs:/var/log/nginx
+    environment:
+      - TZ=Asia/Seoul
+
+  certbot:
+    image: certbot/certbot
+    container_name: gateway-certbot
+    volumes:
+      - ./nginx/letsencrypt:/etc/letsencrypt
+      - ./nginx/www:/var/www/certbot
+    depends_on:
+      - nginx

--- a/gateway/nginx/nginx.conf
+++ b/gateway/nginx/nginx.conf
@@ -1,0 +1,53 @@
+worker_processes  auto;
+events { worker_connections 1024; }
+
+http {
+    server {
+        listen 80;
+        server_name chart-pattern.frieeren.com time-align.frieeren.com;
+
+        location /.well-known/acme-challenge/ {
+            allow all;
+            root /var/www/certbot;
+        }
+
+        location / {
+            return 301 https://$host$request_uri;
+        }
+    }
+
+
+    # chart-pattern
+    server {
+        listen 443 ssl;
+        server_name chart-pattern.frieeren.com;
+
+        ssl_certificate /etc/letsencrypt/live/chart-pattern.frieeren.com/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/chart-pattern.frieeren.com/privkey.pem;
+
+        location / { 
+            proxy_pass http://frieeren.ddns.net:3001;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+
+    # time-align
+    server {
+        listen 443 ssl;
+        server_name time-align.frieeren.com;
+
+        ssl_certificate /etc/letsencrypt/live/time-align.frieeren.com/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/time-align.frieeren.com/privkey.pem;
+
+        location / { 
+            proxy_pass http://frieeren.ddns.net:3002;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+}


### PR DESCRIPTION
## 설명
하나의 서비스만 존재할때는 해당 서비스의 repo에서 인증서 관리와 함께 진입점을 관리했습니다.
N개의 서비스를 관리하기 위해 진입점이 될 nginx를 새로 만들고 인증서도 진입점에서 관리하도록 변경하고자 합니다.

## 이슈
close #4 

## Change
- 진입점 nginx 추가
- 인증서를 위한 certbot 추가
- docker compose 를 이용한 서비스 관리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a gateway with Nginx reverse proxy and automated SSL via Certbot.
  * Enabled HTTPS with automatic HTTP-to-HTTPS redirects for chart-pattern and time-align domains.
  * Improved routing stability by proxying requests to backend services.
* **Chores**
  * Updated ignore rules to exclude environment files and gateway-related artifacts and logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->